### PR TITLE
ccv_fontFamily attribute added

### DIFF
--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -1,39 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical"
-        tools:context=".MainActivity">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    tools:context=".MainActivity">
 
     <com.github.okdroid.checkablechipview.CheckableChipView
-            android:id="@+id/chip0"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Sample 0"/>
+        android:id="@+id/chip0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Sample 0" />
 
     <com.github.okdroid.checkablechipview.CheckableChipView
-            android:color="#FFC107"
-            android:id="@+id/chip1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="Sample 1"
-            app:ccv_outlineColor="#FFC107"/>
+        android:id="@+id/chip1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:color="#FFC107"
+        android:text="Sample 1"
+        app:ccv_outlineColor="#FFC107" />
 
     <com.github.okdroid.checkablechipview.CheckableChipView
-            android:id="@+id/chip2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="Sample 2"
-            android:color="@color/colorAccent"
-            app:ccv_outlineColor="@color/colorAccent"
-            app:ccv_outlineCornerRadius="6dp"
-            app:ccv_checkedTextColor="?android:textColorPrimaryInverse"
-            app:ccv_outlineWidth="2dp"/>
+        android:id="@+id/chip2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:color="@color/colorAccent"
+        android:text="Sample 2"
+        app:ccv_checkedTextColor="?android:textColorPrimaryInverse"
+        app:ccv_outlineColor="@color/colorAccent"
+        app:ccv_outlineCornerRadius="6dp"
+        app:ccv_outlineWidth="2dp" />
 
 </LinearLayout>

--- a/lib/src/main/java/com/github/okdroid/checkablechipview/CheckableChipView.kt
+++ b/lib/src/main/java/com/github/okdroid/checkablechipview/CheckableChipView.kt
@@ -20,10 +20,7 @@ package com.github.okdroid.checkablechipview
 
 import android.animation.ValueAnimator
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Outline
-import android.graphics.Paint
+import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.M
@@ -33,6 +30,7 @@ import android.text.Layout.Alignment.ALIGN_NORMAL
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.util.AttributeSet
+import android.util.Log
 import android.view.SoundEffectConstants
 import android.view.View
 import android.view.ViewOutlineProvider
@@ -51,6 +49,7 @@ import androidx.core.graphics.withScale
 import androidx.core.graphics.withTranslation
 import kotlin.properties.ObservableProperty
 import kotlin.reflect.KProperty
+
 
 /**
  * A custom view for displaying filters. Allows a custom presentation of the tag color and selection
@@ -111,6 +110,12 @@ class CheckableChipView @JvmOverloads constructor(
      */
     var onCheckedChangeListener: ((view: CheckableChipView, checked: Boolean) -> Unit)? = null
 
+    /**
+     * Set typeface
+     */
+    var font:String? by viewProperty("")
+
+
     private var targetProgress: Float = 0f
 
     private var progress: Float by viewProperty(0f) {
@@ -150,7 +155,9 @@ class CheckableChipView @JvmOverloads constructor(
             if (hasValue(R.styleable.CheckableChipView_ccv_outlineCornerRadius)) {
                 outlineCornerRadius = getDimensionOrThrow(R.styleable.CheckableChipView_ccv_outlineCornerRadius)
             }
-
+            if (hasValue(R.styleable.CheckableChipView_ccv_fontFamily)){
+                font  = getString(R.styleable.CheckableChipView_ccv_fontFamily)
+            }
             checkedColor = getColor(R.styleable.CheckableChipView_android_color, checkedColor)
             checkedTextColor = getColor(R.styleable.CheckableChipView_ccv_checkedTextColor, Color.TRANSPARENT)
             defaultTextColor = getColorOrThrow(R.styleable.CheckableChipView_android_textColor)
@@ -268,6 +275,9 @@ class CheckableChipView @JvmOverloads constructor(
             progress
         )
 
+        // setTypeface
+        setTypeface(context, font)
+
         textPaint.apply {
             textSize = this@CheckableChipView.textSize
             color = when {
@@ -349,6 +359,18 @@ class CheckableChipView @JvmOverloads constructor(
             @Suppress("DEPRECATION")
             StaticLayout(text, textPaint, textWidth, ALIGN_NORMAL, 1f, 0f, true)
         }
+    }
+
+    private fun setTypeface(ctx: Context, asset: String?): Boolean {
+        val tf: Typeface
+        tf = try {
+            Typeface.createFromAsset(ctx.assets, asset)
+        } catch (e: Exception) {
+            Log.e(context.packageName, "Could not get typeface: ${e.message}Place your fonts in assets folder to access ccv_fontFamily attribute.".trimIndent())
+            return false
+        }
+        textPaint.typeface = tf
+        return true
     }
 
     override fun verifyDrawable(who: Drawable): Boolean {

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -35,6 +35,8 @@
 
         <attr name="ccv_foreground" format="reference"/>
         <attr name="ccv_clearIcon" format="reference"/>
+
+        <attr name="ccv_fontFamily" format="string"/>
     </declare-styleable>
 
     <style name="Widget.CheckableChipView" parent="">


### PR DESCRIPTION
I added **ccv_fontFamily** attribute to the project.
You just need place your **.ttf** fonts  in asset folder. 
Then xml layout should be like this.
```xml
    <com.github.okdroid.checkablechipview.CheckableChipView
        android:id="@+id/chip2"
        android:layout_width="wrap_content"
        android:layout_height="wrap_content"
        app:ccv_fontFamily="YOUR_FONT.ttf"
        android:color="@color/colorAccent"
        android:text="Sample 2"
        app:ccv_checkedTextColor="?android:textColorPrimaryInverse"
        app:ccv_outlineColor="@color/colorAccent"
        app:ccv_outlineCornerRadius="6dp"
        app:ccv_outlineWidth="2dp" />
```

![Screenshot_20200904-223029_CheckableChipViewDemo 1](https://user-images.githubusercontent.com/44994380/92272385-affe3d80-eefe-11ea-9cea-81bfd1efe9c0.jpg)
![Screenshot_20200904-223034_CheckableChipViewDemo 1](https://user-images.githubusercontent.com/44994380/92272420-bc829600-eefe-11ea-8025-6bacbe9c9e8c.jpg)
